### PR TITLE
feature: add news remote container

### DIFF
--- a/packages/host/index.js
+++ b/packages/host/index.js
@@ -10,6 +10,7 @@ import {name as appName} from './app.json';
 const resolveURL = Federated.createURLResolver({
   containers: {
     booking: 'http://localhost:9000/[name][ext]',
+    news: `https://callstack-internal.github.io/news-mini-app-template/build/generated/${Platform.OS}/[name][ext]`,
   },
 });
 

--- a/packages/host/src/data/services.json
+++ b/packages/host/src/data/services.json
@@ -1,25 +1,25 @@
 {
     "data": [
         {
-            "id": "1",
+            "id": "booking",
             "title": "Booking",
             "description": "Check your schedule",
             "image": "https://picsum.photos/700"
         },
         {
-            "id": "2",
+            "id": "shopping",
             "title": "Shopping",
             "description": "Explore new products",
             "image": "https://picsum.photos/700"
         },
         {
-            "id": "3",
+            "id": "news",
             "title": "News and articles",
             "description": "Read and inspire",
             "image": "https://picsum.photos/700"
         },
         {
-            "id": "4",
+            "id": "dashboard",
             "title": "Dashboard",
             "description": "Manage your business",
             "image": "https://picsum.photos/700"

--- a/packages/host/src/navigation/MainNavigator.tsx
+++ b/packages/host/src/navigation/MainNavigator.tsx
@@ -3,10 +3,12 @@ import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import BookingScreen from '../screens/BookingScreen';
 import TabsNavigator from './TabsNavigator';
 import NavBar from '../components/NavBar';
+import NewsScreen from '../screens/NewsScreen';
 
 export type MainStackParamList = {
   Tabs: undefined;
   Booking: undefined;
+  News: undefined;
 };
 
 const Main = createNativeStackNavigator<MainStackParamList>();
@@ -27,6 +29,13 @@ const MainNavigator = () => {
       <Main.Screen
         name="Booking"
         component={BookingScreen}
+        options={{
+          title: '',
+        }}
+      />
+      <Main.Screen
+        name="News"
+        component={NewsScreen}
         options={{
           title: '',
         }}

--- a/packages/host/src/screens/NewsScreen.tsx
+++ b/packages/host/src/screens/NewsScreen.tsx
@@ -1,0 +1,16 @@
+import {Federated} from '@callstack/repack/client';
+import React from 'react';
+import Placeholder from '../components/Placeholder';
+
+const News = React.lazy(() => Federated.importModule('news', './App'));
+
+const NewsScreen = () => {
+  return (
+    <React.Suspense
+      fallback={<Placeholder label="News and Articles" icon="newspaper" />}>
+      <News />
+    </React.Suspense>
+  );
+};
+
+export default NewsScreen;

--- a/packages/host/src/screens/ServicesScreen.tsx
+++ b/packages/host/src/screens/ServicesScreen.tsx
@@ -1,5 +1,11 @@
 import React, {useCallback} from 'react';
-import {FlatList, ListRenderItemInfo, StyleSheet, View} from 'react-native';
+import {
+  Alert,
+  FlatList,
+  ListRenderItemInfo,
+  StyleSheet,
+  View,
+} from 'react-native';
 import {CompositeScreenProps} from '@react-navigation/native';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {MainStackParamList} from '../navigation/MainNavigator';
@@ -25,13 +31,29 @@ const ServicesScreen = ({navigation}: ServiceScreenProps) => {
     [navigation],
   );
 
+  const openNews = useCallback(() => navigation.navigate('News'), [navigation]);
+
   const renderItem = useCallback(
     ({item, index}: ListRenderItemInfo<ServiceMenuItem>) => {
       const lastItem = index === services.data.length - 1;
+      let onPress;
+
+      switch (item.id) {
+        case 'booking':
+          onPress = openBooking;
+          break;
+        case 'news':
+          onPress = openNews;
+          break;
+        default:
+          onPress = () => Alert.alert('Not implemented yet');
+
+          break;
+      }
 
       return (
         <View style={[styles.serviceItem, lastItem && styles.lastServiceItem]}>
-          <Card mode="contained" onPress={openBooking} style={styles.cardItem}>
+          <Card mode="contained" onPress={onPress} style={styles.cardItem}>
             <Card.Cover source={{uri: item.image}} />
             <Card.Content>
               <Title numberOfLines={1}>{item.title}</Title>
@@ -41,7 +63,7 @@ const ServicesScreen = ({navigation}: ServiceScreenProps) => {
         </View>
       );
     },
-    [openBooking],
+    [openBooking, openNews],
   );
 
   return (


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Added News mini app usage into host application.
News mini app was deployed in GH Pages in this repo https://github.com/callstack-internal/news-mini-app-template.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
1. Open Services screen
2. Open News screen
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
