### PR TITLE
chore: change news remote container url

### DIFF
--- a/packages/host/index.js
+++ b/packages/host/index.js
@@ -10,7 +10,7 @@ import {name as appName} from './app.json';
 const resolveURL = Federated.createURLResolver({
   containers: {
     booking: 'http://localhost:9000/[name][ext]',
-    news: `https://callstack-internal.github.io/news-mini-app-template/build/generated/${Platform.OS}/[name][ext]`,
+    news: `https://raw.githubusercontent.com/callstack-internal/news-mini-app-template/main/build/generated/${Platform.OS}/[name][ext]`,
   },
 });
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Should be merged after https://github.com/callstack-internal/news-mini-app-template/pull/3 to provide new url for downloading news remote container bundle
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
1. Open Services screen
2. Open News mini app
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
