### PR TITLE
fix: remove navigation container independent prop

### DIFF
--- a/packages/booking/src/App.tsx
+++ b/packages/booking/src/App.tsx
@@ -4,7 +4,7 @@ import MainNavigator from './navigation/MainNavigator';
 
 const App = () => {
   return (
-    <NavigationContainer independent>
+    <NavigationContainer>
       <MainNavigator />
     </NavigationContainer>
   );

--- a/packages/booking/webpack.config.mjs
+++ b/packages/booking/webpack.config.mjs
@@ -248,7 +248,7 @@ export default env => {
          * This is a list of modules that will be shared between remote containers.
          */
         exposes: {
-          './App': './src/App',
+          './App': './src/navigation/MainNavigator',
           './UpcomingScreen': './src/screens/UpcomingScreen',
         },
         /**

--- a/packages/host/src/App.tsx
+++ b/packages/host/src/App.tsx
@@ -4,7 +4,7 @@ import MainNavigator from './navigation/MainNavigator';
 
 const App = () => {
   return (
-    <NavigationContainer independent>
+    <NavigationContainer>
       <MainNavigator />
     </NavigationContainer>
   );


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Remove `NavigationContainer` independent prop to prevent independent navigation between host and mini apps
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
