### PR TITLE
fix: mini app navbar back button

### DIFF
--- a/packages/booking/webpack.config.mjs
+++ b/packages/booking/webpack.config.mjs
@@ -295,6 +295,11 @@ export default env => {
             eager: STANDALONE,
             requiredVersion: '6.2.4',
           },
+          'react-native-paper': {
+            singleton: true,
+            eager: true,
+            requiredVersion: '5.0.0-rc.8',
+          },
         },
       }),
     ],

--- a/packages/dashboard/webpack.config.mjs
+++ b/packages/dashboard/webpack.config.mjs
@@ -294,6 +294,11 @@ export default env => {
             eager: STANDALONE,
             requiredVersion: '6.2.4',
           },
+          'react-native-paper': {
+            singleton: true,
+            eager: true,
+            requiredVersion: '5.0.0-rc.8',
+          },
         },
       }),
     ],

--- a/packages/host/webpack.config.mjs
+++ b/packages/host/webpack.config.mjs
@@ -278,6 +278,11 @@ export default env => {
             eager: true,
             requiredVersion: '6.2.4',
           },
+          'react-native-paper': {
+            singleton: true,
+            eager: true,
+            requiredVersion: '5.0.0-rc.8',
+          },
         },
       }),
     ],


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
NavBar back button icon was not visible when `react-native-calendar` module used inside the app. To prevent this behaviour `react-native-paper` lib which provides NavBar component should be in shared dependencies inside webpack config

https://user-images.githubusercontent.com/6783062/204675604-fcfc081c-943e-4282-bba7-75a8c6a920a3.mp4



<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
1. Open Services screen
2. Open Booking app
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
