### PR TITLE
setup android release config

### DIFF
--- a/packages/host/android/app/build.gradle
+++ b/packages/host/android/app/build.gradle
@@ -27,7 +27,7 @@ react {
     // nodeExecutableAndArgs = ["node"]
     //
     //   The command to run when bundling. By default is 'bundle'
-    // bundleCommand = "ram-bundle"
+    bundleCommand = "webpack-bundle"
     //
     //   The path to the CLI configuration file. Default is empty.
     // bundleConfig = file(../rn-cli.config.js)
@@ -117,6 +117,14 @@ android {
             keyAlias 'androiddebugkey'
             keyPassword 'android'
         }
+        release {
+            if (project.hasProperty('SUPERAPPTEMPLATE_UPLOAD_STORE_FILE')) {
+                storeFile file(SUPERAPPTEMPLATE_UPLOAD_STORE_FILE)
+                storePassword SUPERAPPTEMPLATE_UPLOAD_STORE_PASSWORD
+                keyAlias SUPERAPPTEMPLATE_UPLOAD_KEY_ALIAS
+                keyPassword SUPERAPPTEMPLATE_UPLOAD_KEY_PASSWORD
+            }
+        }
     }
     buildTypes {
         debug {
@@ -125,7 +133,7 @@ android {
         release {
             // Caution! In production, you need to generate your own keystore file.
             // see https://reactnative.dev/docs/signed-apk-android.
-            signingConfig signingConfigs.debug
+            signingConfig signingConfigs.release
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Prepare app for android release

### Test plan

To build:
```
yarn react-native run-android --mode release
```

To test locally:
```
yarn react-native run-android --mode release
```

Note: since http server is http, not https, you'll need to turn on `android:usesCleartextTraffic="true"` locally in main AndroidManifest.xml for the app to be able to resolve `catalog-server` served modules and mini-apps.
