### PR TITLE
fix: update location for news mini-app

### DIFF
--- a/packages/catalog-server/data/host.json
+++ b/packages/catalog-server/data/host.json
@@ -3,7 +3,7 @@
     "0.0.1": {
       "booking": "http://localhost:9000/[name][ext]",
       "shopping": "http://localhost:9001/[name][ext]",
-      "news": "https://raw.githubusercontent.com/callstack/news-mini-app-showcase/main/build/outputs/ios/remotes/[name][ext]",
+      "news": "https://github.com/callstack/news-mini-app-showcase/releases/download/news-ios@0.0.1/[name][ext]",
       "dashboard": "http://localhost:9002/[name][ext]",
       "auth": "http://localhost:9003/[name][ext]"
     }
@@ -12,7 +12,7 @@
     "0.0.1": {
       "booking": "http://localhost:9000/[name][ext]",
       "shopping": "http://localhost:9001/[name][ext]",
-      "news": "https://raw.githubusercontent.com/callstack/news-mini-app-showcase/main/build/outputs/android/remotes/[name][ext]",
+      "news": "https://github.com/callstack/news-mini-app-showcase/releases/download/news-android@0.0.1/[name][ext]",
       "dashboard": "http://localhost:9002/[name][ext]",
       "auth": "http://localhost:9003/[name][ext]"
     }


### PR DESCRIPTION
### Summary

As news miniapp is now hosted using GitHub releases, the location of 'news' in the catalog-server needed adjusting
