### PR TITLE
chore: upgrade repack to 3.4.0

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -24,7 +24,7 @@
     "@babel/core": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "@babel/runtime": "^7.20.0",
-    "@callstack/repack": "^3.2.0",
+    "@callstack/repack": "~3.4.0",
     "@react-native-community/eslint-config": "^3.2.0",
     "@tsconfig/react-native": "^2.0.2",
     "@types/jest": "^29.2.1",

--- a/packages/booking/package.json
+++ b/packages/booking/package.json
@@ -31,7 +31,7 @@
     "@babel/core": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "@babel/runtime": "^7.20.0",
-    "@callstack/repack": "^3.2.0",
+    "@callstack/repack": "~3.4.0",
     "@react-native-community/eslint-config": "^3.2.0",
     "@tsconfig/react-native": "^2.0.2",
     "@types/jest": "^29.2.1",

--- a/packages/dashboard/ios/Podfile.lock
+++ b/packages/dashboard/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - boost (1.76.0)
-  - callstack-repack (3.2.0):
-    - JWTDecode (~> 3.0)
+  - callstack-repack (3.4.0):
+    - JWTDecode (~> 3.0.0)
     - React-Core
-    - SwiftyRSA
+    - SwiftyRSA (~> 1.7)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.71.8)
@@ -607,7 +607,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  callstack-repack: 3e48a96824e0e0411ae1f48749a2ab103aa62a3a
+  callstack-repack: 7ebeb152e5a2388d8c840e35e0058d933a73e1b4
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: f637f31eacba90d4fdeff3fa41608b8f361c173b

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -36,7 +36,7 @@
     "@babel/core": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "@babel/runtime": "^7.20.0",
-    "@callstack/repack": "^3.2.0",
+    "@callstack/repack": "~3.4.0",
     "@react-native-community/eslint-config": "^3.2.0",
     "@tsconfig/react-native": "^2.0.2",
     "@types/jest": "^29.2.1",

--- a/packages/host/ios/Podfile.lock
+++ b/packages/host/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - boost (1.76.0)
-  - callstack-repack (3.2.0):
-    - JWTDecode (~> 3.0)
+  - callstack-repack (3.4.0):
+    - JWTDecode (~> 3.0.0)
     - React-Core
-    - SwiftyRSA
+    - SwiftyRSA (~> 1.7)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.71.8)
@@ -612,7 +612,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  callstack-repack: 3e48a96824e0e0411ae1f48749a2ab103aa62a3a
+  callstack-repack: 7ebeb152e5a2388d8c840e35e0058d933a73e1b4
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: f637f31eacba90d4fdeff3fa41608b8f361c173b

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -33,7 +33,7 @@
     "@babel/core": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "@babel/runtime": "^7.20.0",
-    "@callstack/repack": "^3.2.0",
+    "@callstack/repack": "~3.4.0",
     "@react-native-community/eslint-config": "^3.2.0",
     "@tsconfig/react-native": "^2.0.2",
     "@types/jest": "^29.2.1",

--- a/packages/shell/ios/Podfile.lock
+++ b/packages/shell/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - boost (1.76.0)
-  - callstack-repack (3.2.0):
-    - JWTDecode (~> 3.0)
+  - callstack-repack (3.4.0):
+    - JWTDecode (~> 3.0.0)
     - React-Core
-    - SwiftyRSA
+    - SwiftyRSA (~> 1.7)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.71.8)
@@ -607,7 +607,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  callstack-repack: 3e48a96824e0e0411ae1f48749a2ab103aa62a3a
+  callstack-repack: 7ebeb152e5a2388d8c840e35e0058d933a73e1b4
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: f637f31eacba90d4fdeff3fa41608b8f361c173b

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -32,7 +32,7 @@
     "@babel/core": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "@babel/runtime": "^7.20.0",
-    "@callstack/repack": "^3.2.0",
+    "@callstack/repack": "~3.4.0",
     "@react-native-community/eslint-config": "^3.2.0",
     "@tsconfig/react-native": "^2.0.2",
     "@types/jest": "^29.2.1",

--- a/packages/shopping/package.json
+++ b/packages/shopping/package.json
@@ -31,7 +31,7 @@
     "@babel/core": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "@babel/runtime": "^7.20.0",
-    "@callstack/repack": "^3.2.0",
+    "@callstack/repack": "~3.4.0",
     "@react-native-community/eslint-config": "^3.2.0",
     "@tsconfig/react-native": "^2.0.2",
     "@types/jest": "^29.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1926,11 +1926,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@callstack/repack@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "@callstack/repack@npm:3.2.0"
+"@callstack/repack@npm:~3.4.0":
+  version: 3.4.0
+  resolution: "@callstack/repack@npm:3.4.0"
   dependencies:
     "@callstack/repack-dev-server": ^1.0.1
+    "@discoveryjs/json-ext": ^0.5.7
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.7
     colorette: ^1.2.2
     dedent: ^0.7.0
@@ -1957,7 +1958,7 @@ __metadata:
     "@react-native-community/cli-types": "*"
     react-native: ">=0.63"
     webpack: 5.x
-  checksum: 39d3586555dc3213726991cb53a10927f7e50ce50fc22dd58df8d692eb676625f17e37b7a178e20516dfa61393e280219c6bf95e5a8f868d820bc7198e4ebd05
+  checksum: 1b7a4c166f69845041e80b7353e21fdc2d4bad5717f3dcd27abab6310211d7b0d4d8bf2acf74e7d6aea28a0bc12c02fa324178a9703d7608887d47e60dddde4b
   languageName: node
   linkType: hard
 
@@ -2194,6 +2195,13 @@ __metadata:
     human-id: ^1.0.2
     prettier: ^2.7.1
   checksum: 40ad8069f9adc565b78a5f25992e31b41a12e551d94c29e1b4def49ce98871a1e358feda6536be8b363a6dba18b1226a22ecfc60fdd7bc1e74bfcf46b07f91be
+  languageName: node
+  linkType: hard
+
+"@discoveryjs/json-ext@npm:^0.5.7":
+  version: 0.5.7
+  resolution: "@discoveryjs/json-ext@npm:0.5.7"
+  checksum: 2176d301cc258ea5c2324402997cf8134ebb212469c0d397591636cea8d3c02f2b3cf9fd58dcb748c7a0dade77ebdc1b10284fa63e608c033a1db52fddc69918
   languageName: node
   linkType: hard
 
@@ -4365,7 +4373,7 @@ __metadata:
     "@babel/core": ^7.20.0
     "@babel/preset-env": ^7.20.0
     "@babel/runtime": ^7.20.0
-    "@callstack/repack": ^3.2.0
+    "@callstack/repack": ~3.4.0
     "@react-native-async-storage/async-storage": ^1.17.11
     "@react-native-community/eslint-config": ^3.2.0
     "@tsconfig/react-native": ^2.0.2
@@ -4677,7 +4685,7 @@ __metadata:
     "@babel/core": ^7.20.0
     "@babel/preset-env": ^7.20.0
     "@babel/runtime": ^7.20.0
-    "@callstack/repack": ^3.2.0
+    "@callstack/repack": ~3.4.0
     "@react-native-async-storage/async-storage": ^1.17.11
     "@react-native-community/eslint-config": ^3.2.0
     "@react-navigation/material-bottom-tabs": ^6.2.5
@@ -5517,7 +5525,7 @@ __metadata:
     "@babel/core": ^7.20.0
     "@babel/preset-env": ^7.20.0
     "@babel/runtime": ^7.20.0
-    "@callstack/repack": ^3.2.0
+    "@callstack/repack": ~3.4.0
     "@react-native-async-storage/async-storage": ^1.17.11
     "@react-native-community/eslint-config": ^3.2.0
     "@react-navigation/material-bottom-tabs": ^6.2.5
@@ -7468,7 +7476,7 @@ __metadata:
     "@babel/core": ^7.20.0
     "@babel/preset-env": ^7.20.0
     "@babel/runtime": ^7.20.0
-    "@callstack/repack": ^3.2.0
+    "@callstack/repack": ~3.4.0
     "@react-native-async-storage/async-storage": ^1.17.11
     "@react-native-community/eslint-config": ^3.2.0
     "@react-navigation/material-bottom-tabs": ^6.2.5
@@ -12154,7 +12162,7 @@ __metadata:
     "@babel/core": ^7.20.0
     "@babel/preset-env": ^7.20.0
     "@babel/runtime": ^7.20.0
-    "@callstack/repack": ^3.2.0
+    "@callstack/repack": ~3.4.0
     "@react-native-async-storage/async-storage": ^1.17.11
     "@react-native-community/eslint-config": ^3.2.0
     "@react-navigation/material-bottom-tabs": ^6.2.5
@@ -12192,7 +12200,7 @@ __metadata:
     "@babel/core": ^7.20.0
     "@babel/preset-env": ^7.20.0
     "@babel/runtime": ^7.20.0
-    "@callstack/repack": ^3.2.0
+    "@callstack/repack": ~3.4.0
     "@react-native-async-storage/async-storage": ^1.17.11
     "@react-native-community/eslint-config": ^3.2.0
     "@react-navigation/material-bottom-tabs": ^6.2.5


### PR DESCRIPTION
### Summary

- Upgrade `Re.Pack` from `3.2.0` to `3.4.0`
- Update `Podfile.lock` files where necessary
