### PR TITLE
chore: add mprocs config for single platform

### DIFF
--- a/mprocs-android.yaml
+++ b/mprocs-android.yaml
@@ -1,0 +1,16 @@
+procs:
+  Host:
+    shell: pnpm start:host --platform android
+    stop: SIGKILL
+  Auth:
+    shell: pnpm start:auth --platform android
+    stop: SIGKILL
+  Booking:
+    shell: pnpm start:booking --platform android
+    stop: SIGKILL
+  Dashboard:
+    shell: pnpm start:dashboard --platform android
+    stop: SIGKILL
+  Shopping:
+    shell: pnpm start:shopping --platform android
+    stop: SIGKILL

--- a/mprocs-ios.yaml
+++ b/mprocs-ios.yaml
@@ -1,0 +1,16 @@
+procs:
+  Host:
+    shell: pnpm start:host --platform ios
+    stop: SIGKILL
+  Auth:
+    shell: pnpm start:auth --platform ios
+    stop: SIGKILL
+  Booking:
+    shell: pnpm start:booking --platform ios
+    stop: SIGKILL
+  Dashboard:
+    shell: pnpm start:dashboard --platform ios
+    stop: SIGKILL
+  Shopping:
+    shell: pnpm start:shopping --platform ios
+    stop: SIGKILL


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Add `mprocs` config to run iOS and Android platforms separately when needed (the dev server runs both targets by default):
```shell
# run ios only:
pnpm start --config mprocs-ios.yaml
# run android only:
pnpm start --config mprocs-android.yaml 
```

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
