### PR TITLE
feat: add `react-native-edge-to-edge`

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -21,6 +21,7 @@
     "react": "18.3.1",
     "react-native": "0.76.3",
     "react-native-bottom-tabs": "0.7.3",
+    "react-native-edge-to-edge": "1.1.3",
     "react-native-paper": "5.12.5",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "4.2.0",

--- a/packages/booking/package.json
+++ b/packages/booking/package.json
@@ -23,6 +23,7 @@
     "react-native": "0.76.3",
     "react-native-bottom-tabs": "0.7.3",
     "react-native-calendars": "1.1291.1",
+    "react-native-edge-to-edge": "1.1.3",
     "react-native-paper": "5.12.5",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "4.2.0",

--- a/packages/dashboard/android/app/src/main/res/values/styles.xml
+++ b/packages/dashboard/android/app/src/main/res/values/styles.xml
@@ -2,7 +2,7 @@
 
     <!-- Base application theme. -->
     <style name="AppTheme"
-        parent="Theme.Material3.DayNight.NoActionBar">
+        parent="Theme.EdgeToEdge.Material3">
         <!-- Customize your theme here. -->
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
     </style>

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -28,6 +28,7 @@
     "react-native": "0.76.3",
     "react-native-bottom-tabs": "0.7.3",
     "react-native-calendars": "1.1291.1",
+    "react-native-edge-to-edge": "1.1.3",
     "react-native-paper": "5.12.5",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "4.2.0",

--- a/packages/host/android/app/src/main/res/values/styles.xml
+++ b/packages/host/android/app/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
     <style name="AppTheme"
-        parent="Theme.Material3.DayNight.NoActionBar">
+        parent="Theme.EdgeToEdge.Material3">
         <!-- Customize your theme here. -->
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
     </style>

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -26,6 +26,7 @@
     "react-native": "0.76.3",
     "react-native-bootsplash": "6.2.6",
     "react-native-bottom-tabs": "0.7.3",
+    "react-native-edge-to-edge": "1.1.3",
     "react-native-paper": "5.12.5",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "4.2.0",

--- a/packages/host/src/components/NavBar.tsx
+++ b/packages/host/src/components/NavBar.tsx
@@ -4,7 +4,7 @@ import {Appbar} from 'react-native-paper';
 
 const NavBar = ({navigation, back, route, options}: NativeStackHeaderProps) => {
   return (
-    <Appbar.Header elevated>
+    <Appbar.Header elevated mode="center-aligned">
       {back ? <Appbar.BackAction onPress={navigation.goBack} /> : null}
       <Appbar.Content title={options.title ?? route.name} />
     </Appbar.Header>

--- a/packages/sdk/lib/dependencies.json
+++ b/packages/sdk/lib/dependencies.json
@@ -47,5 +47,9 @@
     "name": "@module-federation/enhanced",
     "version": "0.7.1",
     "shared": false
+  },
+  "react-native-edge-to-edge": {
+    "name": "react-native-edge-to-edge",
+    "version": "1.1.3"
   }
 }

--- a/packages/shopping/package.json
+++ b/packages/shopping/package.json
@@ -22,6 +22,7 @@
     "react": "18.3.1",
     "react-native": "0.76.3",
     "react-native-bottom-tabs": "0.7.3",
+    "react-native-edge-to-edge": "1.1.3",
     "react-native-paper": "5.12.5",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       react-native-bottom-tabs:
         specifier: 0.7.3
         version: 0.7.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-edge-to-edge:
+        specifier: 1.1.3
+        version: 1.1.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-paper:
         specifier: 5.12.5
         version: 5.12.5(patch_hash=y63saubgvw44zriplyaexrq2dy)(react-native-safe-area-context@4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-vector-icons@10.2.0)(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -178,6 +181,9 @@ importers:
       react-native-calendars:
         specifier: 1.1291.1
         version: 1.1291.1(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-edge-to-edge:
+        specifier: 1.1.3
+        version: 1.1.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-paper:
         specifier: 5.12.5
         version: 5.12.5(patch_hash=y63saubgvw44zriplyaexrq2dy)(react-native-safe-area-context@4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-vector-icons@10.2.0)(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -305,6 +311,9 @@ importers:
       react-native-calendars:
         specifier: 1.1291.1
         version: 1.1291.1(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-edge-to-edge:
+        specifier: 1.1.3
+        version: 1.1.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-paper:
         specifier: 5.12.5
         version: 5.12.5(patch_hash=y63saubgvw44zriplyaexrq2dy)(react-native-safe-area-context@4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-vector-icons@10.2.0)(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -432,6 +441,9 @@ importers:
       react-native-bottom-tabs:
         specifier: 0.7.3
         version: 0.7.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-edge-to-edge:
+        specifier: 1.1.3
+        version: 1.1.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-paper:
         specifier: 5.12.5
         version: 5.12.5(patch_hash=y63saubgvw44zriplyaexrq2dy)(react-native-safe-area-context@4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-vector-icons@10.2.0)(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -561,6 +573,9 @@ importers:
       react-native-bottom-tabs:
         specifier: 0.7.3
         version: 0.7.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-edge-to-edge:
+        specifier: 1.1.3
+        version: 1.1.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-paper:
         specifier: 5.12.5
         version: 5.12.5(patch_hash=y63saubgvw44zriplyaexrq2dy)(react-native-safe-area-context@4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-vector-icons@10.2.0)(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -4680,6 +4695,12 @@ packages:
 
   react-native-calendars@1.1291.1:
     resolution: {integrity: sha512-L2MK2t3kbnDg2RoU12UAoQyNrUpDYdj2MyIfg13YrwVb8BuI/gc0q/VpEinY3iz5ETHiFsTLkCsAFwSj7xbZWw==}
+
+  react-native-edge-to-edge@1.1.3:
+    resolution: {integrity: sha512-+as8PmGZCvZtHbHT2xXH0YFH1qqBpFVH14Pzk0+6fI53zWMa56m5HY9S1mhIBgPjdqLBM8Y6KresI1/MUI86pw==}
+    peerDependencies:
+      react: '>=18.2.0'
+      react-native: '>=0.73.0'
 
   react-native-is-edge-to-edge@1.1.6:
     resolution: {integrity: sha512-1pHnFTlBahins6UAajXUqeCOHew9l9C2C8tErnpGC3IyLJzvxD+TpYAixnCbrVS52f7+NvMttbiSI290XfwN0w==}
@@ -10827,6 +10848,11 @@ snapshots:
     transitivePeerDependencies:
       - react
       - react-native
+
+  react-native-edge-to-edge@1.1.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-native: 0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1)
 
   react-native-is-edge-to-edge@1.1.6(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
     dependencies:


### PR DESCRIPTION
### Summary

added `react-native-edge-to-edge` to uniform look on both platforms:

| ios | android |
| - | - |
| ![image](https://github.com/user-attachments/assets/e901cd26-9a76-4f98-9b2b-8e33a0b94768) | ![image](https://github.com/user-attachments/assets/c0cf5a9c-3275-44a4-8d02-8a8402b756ae) |


### Test plan

n/a
