### PR TITLE
fix: styling, types

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -13,14 +13,14 @@
     "check-deps": "rnx-align-deps"
   },
   "dependencies": {
-    "@bottom-tabs/react-navigation": "0.7.4",
+    "@bottom-tabs/react-navigation": "0.7.6",
     "@module-federation/enhanced": "0.7.1",
     "@react-native-async-storage/async-storage": "2.0.0",
     "@react-navigation/native": "7.0.13",
     "@react-navigation/native-stack": "7.1.14",
     "react": "18.3.1",
     "react-native": "0.76.3",
-    "react-native-bottom-tabs": "0.7.4",
+    "react-native-bottom-tabs": "0.7.6",
     "react-native-edge-to-edge": "1.1.3",
     "react-native-paper": "5.12.5",
     "react-native-safe-area-context": "4.12.0",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -13,14 +13,14 @@
     "check-deps": "rnx-align-deps"
   },
   "dependencies": {
-    "@bottom-tabs/react-navigation": "0.7.3",
+    "@bottom-tabs/react-navigation": "0.7.4",
     "@module-federation/enhanced": "0.7.1",
     "@react-native-async-storage/async-storage": "2.0.0",
     "@react-navigation/native": "7.0.13",
     "@react-navigation/native-stack": "7.1.14",
     "react": "18.3.1",
     "react-native": "0.76.3",
-    "react-native-bottom-tabs": "0.7.3",
+    "react-native-bottom-tabs": "0.7.4",
     "react-native-edge-to-edge": "1.1.3",
     "react-native-paper": "5.12.5",
     "react-native-safe-area-context": "4.12.0",

--- a/packages/booking/package.json
+++ b/packages/booking/package.json
@@ -14,14 +14,14 @@
     "check-deps": "rnx-align-deps"
   },
   "dependencies": {
-    "@bottom-tabs/react-navigation": "0.7.4",
+    "@bottom-tabs/react-navigation": "0.7.6",
     "@module-federation/enhanced": "0.7.1",
     "@react-native-async-storage/async-storage": "2.0.0",
     "@react-navigation/native": "7.0.13",
     "@react-navigation/native-stack": "7.1.14",
     "react": "18.3.1",
     "react-native": "0.76.3",
-    "react-native-bottom-tabs": "0.7.4",
+    "react-native-bottom-tabs": "0.7.6",
     "react-native-calendars": "1.1291.1",
     "react-native-edge-to-edge": "1.1.3",
     "react-native-paper": "5.12.5",

--- a/packages/booking/package.json
+++ b/packages/booking/package.json
@@ -14,14 +14,14 @@
     "check-deps": "rnx-align-deps"
   },
   "dependencies": {
-    "@bottom-tabs/react-navigation": "0.7.3",
+    "@bottom-tabs/react-navigation": "0.7.4",
     "@module-federation/enhanced": "0.7.1",
     "@react-native-async-storage/async-storage": "2.0.0",
     "@react-navigation/native": "7.0.13",
     "@react-navigation/native-stack": "7.1.14",
     "react": "18.3.1",
     "react-native": "0.76.3",
-    "react-native-bottom-tabs": "0.7.3",
+    "react-native-bottom-tabs": "0.7.4",
     "react-native-calendars": "1.1291.1",
     "react-native-edge-to-edge": "1.1.3",
     "react-native-paper": "5.12.5",

--- a/packages/booking/src/components/NavBar.tsx
+++ b/packages/booking/src/components/NavBar.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import {NativeStackHeaderProps} from '@react-navigation/native-stack';
-import {Appbar} from 'react-native-paper';
+import {Appbar, MD3Colors} from 'react-native-paper';
 
 const NavBar = ({navigation, back, route, options}: NativeStackHeaderProps) => {
   return (
-    <Appbar.Header elevated>
+    <Appbar.Header elevated style={{backgroundColor: MD3Colors.primary95}}>
       {back ? <Appbar.BackAction onPress={navigation.goBack} /> : null}
       <Appbar.Content title={options.title ?? route.name} />
     </Appbar.Header>

--- a/packages/booking/src/navigation/TabsNavigator.tsx
+++ b/packages/booking/src/navigation/TabsNavigator.tsx
@@ -20,7 +20,9 @@ const Tabs = createNativeBottomTabNavigator<TabsParamList>();
 
 const TabsNavigator = () => {
   return (
-    <Tabs.Navigator tabBarActiveTintColor={MD3Colors.primary50}>
+    <Tabs.Navigator
+      translucent={false}
+      tabBarActiveTintColor={MD3Colors.primary50}>
       <Tabs.Screen
         name="HomeNavigator"
         component={HomeNavigator}

--- a/packages/booking/src/navigation/TabsNavigator.tsx
+++ b/packages/booking/src/navigation/TabsNavigator.tsx
@@ -22,7 +22,8 @@ const TabsNavigator = () => {
   return (
     <Tabs.Navigator
       translucent={false}
-      tabBarActiveTintColor={MD3Colors.primary50}>
+      tabBarActiveTintColor={MD3Colors.primary50}
+      barTintColor={MD3Colors.primary95}>
       <Tabs.Screen
         name="HomeNavigator"
         component={HomeNavigator}

--- a/packages/booking/src/screens/HomeScreen.tsx
+++ b/packages/booking/src/screens/HomeScreen.tsx
@@ -9,14 +9,8 @@ import {
 } from 'react-native';
 import {CompositeScreenProps} from '@react-navigation/native';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
-import {
-  Avatar,
-  Card,
-  Button,
-  Divider,
-  Text,
-  MaterialBottomTabScreenProps,
-} from 'react-native-paper';
+import {NativeBottomTabScreenProps} from '@bottom-tabs/react-navigation';
+import {Avatar, Card, Button, Divider, Text} from 'react-native-paper';
 import {TabsParamList} from '../navigation/TabsNavigator';
 import {HomeStackParamList} from '../navigation/HomeNavigator';
 import upcomingBookings from '../data/upcomingBookings.json';
@@ -25,7 +19,7 @@ import featuredServices from '../data/featuredServices.json';
 
 type Props = CompositeScreenProps<
   NativeStackScreenProps<HomeStackParamList>,
-  MaterialBottomTabScreenProps<TabsParamList, 'HomeNavigator'>
+  NativeBottomTabScreenProps<TabsParamList, 'HomeNavigator'>
 >;
 
 const renderAppointment = ({item}: any) => (

--- a/packages/dashboard/ios/Podfile.lock
+++ b/packages/dashboard/ios/Podfile.lock
@@ -1266,7 +1266,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-bottom-tabs (0.7.4):
+  - react-native-bottom-tabs (0.7.6):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1279,7 +1279,7 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
-    - react-native-bottom-tabs/common (= 0.7.4)
+    - react-native-bottom-tabs/common (= 0.7.6)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -1291,7 +1291,7 @@ PODS:
     - SDWebImageSVGCoder (>= 1.7.0)
     - SwiftUIIntrospect (~> 1.0)
     - Yoga
-  - react-native-bottom-tabs/common (0.7.4):
+  - react-native-bottom-tabs/common (0.7.6):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1738,7 +1738,7 @@ PODS:
   - SDWebImage (5.20.0):
     - SDWebImage/Core (= 5.20.0)
   - SDWebImage/Core (5.20.0)
-  - SDWebImageSVGCoder (1.7.0):
+  - SDWebImageSVGCoder (1.8.0):
     - SDWebImage/Core (~> 5.6)
   - SocketRocket (0.7.1)
   - SwiftUIIntrospect (1.3.0)
@@ -2010,7 +2010,7 @@ SPEC CHECKSUMS:
   React-logger: 26155dc23db5c9038794db915f80bd2044512c2e
   React-Mapbuffer: ad1ba0205205a16dbff11b8ade6d1b3959451658
   React-microtasksnativemodule: e771eb9eb6ace5884ee40a293a0e14a9d7a4343c
-  react-native-bottom-tabs: 7ce16518e2a0e664bd38bec2b49c50bde4a1bdc7
+  react-native-bottom-tabs: efc4265bb52b9b7a67fc30965b51cdf84f5be3cd
   react-native-safe-area-context: 458f6b948437afcb59198016b26bbd02ff9c3b47
   React-nativeconfig: aeed6e2a8ac02b2df54476afcc7c663416c12bf7
   React-NativeModulesApple: c5b7813da94136f50ef084fa1ac077332dcfc658
@@ -2043,7 +2043,7 @@ SPEC CHECKSUMS:
   RNScreens: 949445ea5fb20daea35cbaba4f482ff98d1a50c6
   RNVectorIcons: 07792a9538e8577c1263fcad187712e90d65d8fb
   SDWebImage: 73c6079366fea25fa4bb9640d5fb58f0893facd8
-  SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
+  SDWebImageSVGCoder: 8e10c8f6cc879c7dfb317b284e13dd589379f01c
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SwiftUIIntrospect: fee9aa07293ee280373a591e1824e8ddc869ba5d
   SwiftyRSA: 8c6dd1ea7db1b8dc4fb517a202f88bb1354bc2c6

--- a/packages/dashboard/ios/Podfile.lock
+++ b/packages/dashboard/ios/Podfile.lock
@@ -1266,7 +1266,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-bottom-tabs (0.7.3):
+  - react-native-bottom-tabs (0.7.4):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1279,7 +1279,7 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
-    - react-native-bottom-tabs/common (= 0.7.3)
+    - react-native-bottom-tabs/common (= 0.7.4)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -1291,7 +1291,7 @@ PODS:
     - SDWebImageSVGCoder (>= 1.7.0)
     - SwiftUIIntrospect (~> 1.0)
     - Yoga
-  - react-native-bottom-tabs/common (0.7.3):
+  - react-native-bottom-tabs/common (0.7.4):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2010,7 +2010,7 @@ SPEC CHECKSUMS:
   React-logger: 26155dc23db5c9038794db915f80bd2044512c2e
   React-Mapbuffer: ad1ba0205205a16dbff11b8ade6d1b3959451658
   React-microtasksnativemodule: e771eb9eb6ace5884ee40a293a0e14a9d7a4343c
-  react-native-bottom-tabs: 826eeae1eec560ca818d433c4657cc5bdf14085e
+  react-native-bottom-tabs: 7ce16518e2a0e664bd38bec2b49c50bde4a1bdc7
   react-native-safe-area-context: 458f6b948437afcb59198016b26bbd02ff9c3b47
   React-nativeconfig: aeed6e2a8ac02b2df54476afcc7c663416c12bf7
   React-NativeModulesApple: c5b7813da94136f50ef084fa1ac077332dcfc658

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -19,14 +19,14 @@
     "check-deps": "rnx-align-deps"
   },
   "dependencies": {
-    "@bottom-tabs/react-navigation": "0.7.3",
+    "@bottom-tabs/react-navigation": "0.7.4",
     "@module-federation/enhanced": "0.7.1",
     "@react-native-async-storage/async-storage": "2.0.0",
     "@react-navigation/native": "7.0.13",
     "@react-navigation/native-stack": "7.1.14",
     "react": "18.3.1",
     "react-native": "0.76.3",
-    "react-native-bottom-tabs": "0.7.3",
+    "react-native-bottom-tabs": "0.7.4",
     "react-native-calendars": "1.1291.1",
     "react-native-edge-to-edge": "1.1.3",
     "react-native-paper": "5.12.5",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -19,14 +19,14 @@
     "check-deps": "rnx-align-deps"
   },
   "dependencies": {
-    "@bottom-tabs/react-navigation": "0.7.4",
+    "@bottom-tabs/react-navigation": "0.7.6",
     "@module-federation/enhanced": "0.7.1",
     "@react-native-async-storage/async-storage": "2.0.0",
     "@react-navigation/native": "7.0.13",
     "@react-navigation/native-stack": "7.1.14",
     "react": "18.3.1",
     "react-native": "0.76.3",
-    "react-native-bottom-tabs": "0.7.4",
+    "react-native-bottom-tabs": "0.7.6",
     "react-native-calendars": "1.1291.1",
     "react-native-edge-to-edge": "1.1.3",
     "react-native-paper": "5.12.5",

--- a/packages/dashboard/src/components/NavBar.tsx
+++ b/packages/dashboard/src/components/NavBar.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import {NativeStackHeaderProps} from '@react-navigation/native-stack';
-import {Appbar} from 'react-native-paper';
+import {Appbar, MD3Colors} from 'react-native-paper';
 
 const NavBar = ({navigation, back, route, options}: NativeStackHeaderProps) => {
   return (
-    <Appbar.Header elevated>
+    <Appbar.Header elevated style={{backgroundColor: MD3Colors.primary95}}>
       {back ? <Appbar.BackAction onPress={navigation.goBack} /> : null}
       <Appbar.Content title={options.title ?? route.name} />
     </Appbar.Header>

--- a/packages/dashboard/src/navigation/TabsNavigator.tsx
+++ b/packages/dashboard/src/navigation/TabsNavigator.tsx
@@ -23,7 +23,9 @@ const Tabs = createNativeBottomTabNavigator<TabsParamList>();
 
 const TabsNavigator = () => {
   return (
-    <Tabs.Navigator tabBarActiveTintColor={MD3Colors.primary50}>
+    <Tabs.Navigator
+      translucent={false}
+      tabBarActiveTintColor={MD3Colors.primary50}>
       <Tabs.Screen
         name="HomeNavigator"
         component={HomeNavigator}

--- a/packages/dashboard/src/navigation/TabsNavigator.tsx
+++ b/packages/dashboard/src/navigation/TabsNavigator.tsx
@@ -25,7 +25,8 @@ const TabsNavigator = () => {
   return (
     <Tabs.Navigator
       translucent={false}
-      tabBarActiveTintColor={MD3Colors.primary50}>
+      tabBarActiveTintColor={MD3Colors.primary50}
+      barTintColor={MD3Colors.primary95}>
       <Tabs.Screen
         name="HomeNavigator"
         component={HomeNavigator}

--- a/packages/host/ios/Podfile.lock
+++ b/packages/host/ios/Podfile.lock
@@ -1266,7 +1266,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-bottom-tabs (0.7.4):
+  - react-native-bottom-tabs (0.7.6):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1279,7 +1279,7 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
-    - react-native-bottom-tabs/common (= 0.7.4)
+    - react-native-bottom-tabs/common (= 0.7.6)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -1291,7 +1291,7 @@ PODS:
     - SDWebImageSVGCoder (>= 1.7.0)
     - SwiftUIIntrospect (~> 1.0)
     - Yoga
-  - react-native-bottom-tabs/common (0.7.4):
+  - react-native-bottom-tabs/common (0.7.6):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1759,7 +1759,7 @@ PODS:
   - SDWebImage (5.20.0):
     - SDWebImage/Core (= 5.20.0)
   - SDWebImage/Core (5.20.0)
-  - SDWebImageSVGCoder (1.7.0):
+  - SDWebImageSVGCoder (1.8.0):
     - SDWebImage/Core (~> 5.6)
   - SocketRocket (0.7.1)
   - SwiftUIIntrospect (1.3.0)
@@ -2034,7 +2034,7 @@ SPEC CHECKSUMS:
   React-logger: 26155dc23db5c9038794db915f80bd2044512c2e
   React-Mapbuffer: ad1ba0205205a16dbff11b8ade6d1b3959451658
   React-microtasksnativemodule: e771eb9eb6ace5884ee40a293a0e14a9d7a4343c
-  react-native-bottom-tabs: 7ce16518e2a0e664bd38bec2b49c50bde4a1bdc7
+  react-native-bottom-tabs: efc4265bb52b9b7a67fc30965b51cdf84f5be3cd
   react-native-safe-area-context: 458f6b948437afcb59198016b26bbd02ff9c3b47
   React-nativeconfig: aeed6e2a8ac02b2df54476afcc7c663416c12bf7
   React-NativeModulesApple: c5b7813da94136f50ef084fa1ac077332dcfc658
@@ -2068,7 +2068,7 @@ SPEC CHECKSUMS:
   RNScreens: 949445ea5fb20daea35cbaba4f482ff98d1a50c6
   RNVectorIcons: 07792a9538e8577c1263fcad187712e90d65d8fb
   SDWebImage: 73c6079366fea25fa4bb9640d5fb58f0893facd8
-  SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
+  SDWebImageSVGCoder: 8e10c8f6cc879c7dfb317b284e13dd589379f01c
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SwiftUIIntrospect: fee9aa07293ee280373a591e1824e8ddc869ba5d
   SwiftyRSA: 8c6dd1ea7db1b8dc4fb517a202f88bb1354bc2c6

--- a/packages/host/ios/Podfile.lock
+++ b/packages/host/ios/Podfile.lock
@@ -1266,7 +1266,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-bottom-tabs (0.7.3):
+  - react-native-bottom-tabs (0.7.4):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1279,7 +1279,7 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
-    - react-native-bottom-tabs/common (= 0.7.3)
+    - react-native-bottom-tabs/common (= 0.7.4)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -1291,7 +1291,7 @@ PODS:
     - SDWebImageSVGCoder (>= 1.7.0)
     - SwiftUIIntrospect (~> 1.0)
     - Yoga
-  - react-native-bottom-tabs/common (0.7.3):
+  - react-native-bottom-tabs/common (0.7.4):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2034,7 +2034,7 @@ SPEC CHECKSUMS:
   React-logger: 26155dc23db5c9038794db915f80bd2044512c2e
   React-Mapbuffer: ad1ba0205205a16dbff11b8ade6d1b3959451658
   React-microtasksnativemodule: e771eb9eb6ace5884ee40a293a0e14a9d7a4343c
-  react-native-bottom-tabs: 826eeae1eec560ca818d433c4657cc5bdf14085e
+  react-native-bottom-tabs: 7ce16518e2a0e664bd38bec2b49c50bde4a1bdc7
   react-native-safe-area-context: 458f6b948437afcb59198016b26bbd02ff9c3b47
   React-nativeconfig: aeed6e2a8ac02b2df54476afcc7c663416c12bf7
   React-NativeModulesApple: c5b7813da94136f50ef084fa1ac077332dcfc658

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -17,7 +17,7 @@
     "check-deps": "rnx-align-deps"
   },
   "dependencies": {
-    "@bottom-tabs/react-navigation": "0.7.4",
+    "@bottom-tabs/react-navigation": "0.7.6",
     "@module-federation/enhanced": "0.7.1",
     "@react-native-async-storage/async-storage": "2.0.0",
     "@react-navigation/native": "7.0.13",
@@ -25,7 +25,7 @@
     "react": "18.3.1",
     "react-native": "0.76.3",
     "react-native-bootsplash": "6.2.6",
-    "react-native-bottom-tabs": "0.7.4",
+    "react-native-bottom-tabs": "0.7.6",
     "react-native-edge-to-edge": "1.1.3",
     "react-native-paper": "5.12.5",
     "react-native-safe-area-context": "4.12.0",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -17,7 +17,7 @@
     "check-deps": "rnx-align-deps"
   },
   "dependencies": {
-    "@bottom-tabs/react-navigation": "0.7.3",
+    "@bottom-tabs/react-navigation": "0.7.4",
     "@module-federation/enhanced": "0.7.1",
     "@react-native-async-storage/async-storage": "2.0.0",
     "@react-navigation/native": "7.0.13",
@@ -25,7 +25,7 @@
     "react": "18.3.1",
     "react-native": "0.76.3",
     "react-native-bootsplash": "6.2.6",
-    "react-native-bottom-tabs": "0.7.3",
+    "react-native-bottom-tabs": "0.7.4",
     "react-native-edge-to-edge": "1.1.3",
     "react-native-paper": "5.12.5",
     "react-native-safe-area-context": "4.12.0",

--- a/packages/host/src/App.tsx
+++ b/packages/host/src/App.tsx
@@ -28,7 +28,7 @@ const App = () => {
 
             return (
               <NavigationContainer
-                onReady={() => RNBootSplash.hide({fade: true, duration: 500})}>
+                onReady={() => RNBootSplash.hide({fade: true})}>
                 <MainNavigator />
               </NavigationContainer>
             );

--- a/packages/host/src/components/NavBar.tsx
+++ b/packages/host/src/components/NavBar.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import {NativeStackHeaderProps} from '@react-navigation/native-stack';
-import {Appbar} from 'react-native-paper';
+import {Appbar, MD3Colors} from 'react-native-paper';
 
 const NavBar = ({navigation, back, route, options}: NativeStackHeaderProps) => {
   return (
-    <Appbar.Header elevated mode="center-aligned">
+    <Appbar.Header
+      elevated
+      mode="center-aligned"
+      style={{backgroundColor: MD3Colors.primary95}}>
       {back ? <Appbar.BackAction onPress={navigation.goBack} /> : null}
       <Appbar.Content title={options.title ?? route.name} />
     </Appbar.Header>

--- a/packages/host/src/navigation/MainNavigator.tsx
+++ b/packages/host/src/navigation/MainNavigator.tsx
@@ -18,10 +18,7 @@ const Main = createNativeStackNavigator<MainStackParamList>();
 
 const MainNavigator = () => {
   return (
-    <Main.Navigator
-      screenOptions={{
-        headerShown: false,
-      }}>
+    <Main.Navigator screenOptions={{headerShown: false}}>
       <Main.Screen name="Tabs" component={TabsNavigator} />
       <Main.Screen name="Booking" component={BookingScreen} />
       <Main.Screen name="Shopping" component={ShoppingScreen} />

--- a/packages/host/src/navigation/TabsNavigator.tsx
+++ b/packages/host/src/navigation/TabsNavigator.tsx
@@ -20,7 +20,9 @@ const Tabs = createNativeBottomTabNavigator<TabsParamList>();
 
 const TabsNavigator = () => {
   return (
-    <Tabs.Navigator tabBarActiveTintColor={MD3Colors.primary50}>
+    <Tabs.Navigator
+      translucent={false}
+      tabBarActiveTintColor={MD3Colors.primary50}>
       <Tabs.Screen
         name="HomeNavigator"
         component={HomeNavigator}

--- a/packages/host/src/navigation/TabsNavigator.tsx
+++ b/packages/host/src/navigation/TabsNavigator.tsx
@@ -22,7 +22,8 @@ const TabsNavigator = () => {
   return (
     <Tabs.Navigator
       translucent={false}
-      tabBarActiveTintColor={MD3Colors.primary50}>
+      tabBarActiveTintColor={MD3Colors.primary50}
+      barTintColor={MD3Colors.primary95}>
       <Tabs.Screen
         name="HomeNavigator"
         component={HomeNavigator}

--- a/packages/host/src/screens/HomeScreen.tsx
+++ b/packages/host/src/screens/HomeScreen.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-native';
 import {CompositeScreenProps} from '@react-navigation/native';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
+import {NativeBottomTabScreenProps} from '@bottom-tabs/react-navigation';
 import {
   Avatar,
   Card,
@@ -16,7 +17,6 @@ import {
   Text,
   Title,
   Paragraph,
-  MaterialBottomTabScreenProps,
 } from 'react-native-paper';
 import {TabsParamList} from '../navigation/TabsNavigator';
 import {HomeStackParamList} from '../navigation/HomeNavigator';
@@ -27,7 +27,7 @@ import recentArticles from '../data/recentArticles.json';
 
 type Props = CompositeScreenProps<
   NativeStackScreenProps<HomeStackParamList>,
-  MaterialBottomTabScreenProps<TabsParamList, 'HomeNavigator'>
+  NativeBottomTabScreenProps<TabsParamList, 'HomeNavigator'>
 >;
 
 const renderUpcoming = ({item}: any) => (

--- a/packages/host/src/screens/HomeScreen.tsx
+++ b/packages/host/src/screens/HomeScreen.tsx
@@ -78,16 +78,18 @@ const renderDivider = () => <Divider style={styles.divider} />;
 
 const HomeScreen = ({navigation}: Props) => {
   return (
-    <ScrollView style={styles.container}
-      contentInsetAdjustmentBehavior="automatic"
-    >
+    <ScrollView
+      style={styles.container}
+      contentInsetAdjustmentBehavior="automatic">
       <View style={styles.header}>
         <Text variant="titleLarge" style={styles.headerTitle}>
           Upcoming Appointments
         </Text>
         <Button
+          compact
           mode="contained-tonal"
-          onPress={() => navigation.navigate('Upcoming')}>
+          onPress={() => navigation.navigate('Upcoming')}
+          style={styles.button}>
           See All
         </Button>
       </View>
@@ -103,7 +105,11 @@ const HomeScreen = ({navigation}: Props) => {
         <Text variant="titleLarge" style={styles.headerTitle}>
           New Products
         </Text>
-        <Button mode="contained-tonal" onPress={() => {}}>
+        <Button
+          compact
+          mode="contained-tonal"
+          onPress={() => {}}
+          style={styles.button}>
           See All
         </Button>
       </View>
@@ -119,7 +125,11 @@ const HomeScreen = ({navigation}: Props) => {
         <Text variant="titleLarge" style={styles.headerTitle}>
           Recent News
         </Text>
-        <Button mode="contained-tonal" onPress={() => {}}>
+        <Button
+          compact
+          mode="contained-tonal"
+          onPress={() => {}}
+          style={styles.button}>
           See All
         </Button>
       </View>
@@ -135,7 +145,11 @@ const HomeScreen = ({navigation}: Props) => {
         <Text variant="titleLarge" style={styles.headerTitle}>
           Recent Articles
         </Text>
-        <Button mode="contained-tonal" onPress={() => {}}>
+        <Button
+          compact
+          mode="contained-tonal"
+          onPress={() => {}}
+          style={styles.button}>
           See All
         </Button>
       </View>
@@ -152,6 +166,9 @@ const HomeScreen = ({navigation}: Props) => {
 };
 
 const styles = StyleSheet.create({
+  button: {
+    paddingHorizontal: 16,
+  },
   container: {
     flex: 1,
     backgroundColor: '#fff',

--- a/packages/sdk/lib/dependencies.json
+++ b/packages/sdk/lib/dependencies.json
@@ -9,7 +9,7 @@
   },
   "@bottom-tabs/react-navigation": {
     "name": "@bottom-tabs/react-navigation",
-    "version": "0.7.3"
+    "version": "0.7.4"
   },
   "@react-native-async-storage/async-storage": {
     "name": "@react-native-async-storage/async-storage",
@@ -25,7 +25,7 @@
   },
   "react-native-bottom-tabs": {
     "name": "react-native-bottom-tabs",
-    "version": "0.7.3"
+    "version": "0.7.4"
   },
   "react-native-paper": {
     "name": "react-native-paper",

--- a/packages/sdk/lib/dependencies.json
+++ b/packages/sdk/lib/dependencies.json
@@ -9,7 +9,7 @@
   },
   "@bottom-tabs/react-navigation": {
     "name": "@bottom-tabs/react-navigation",
-    "version": "0.7.4"
+    "version": "0.7.6"
   },
   "@react-native-async-storage/async-storage": {
     "name": "@react-native-async-storage/async-storage",
@@ -25,7 +25,7 @@
   },
   "react-native-bottom-tabs": {
     "name": "react-native-bottom-tabs",
-    "version": "0.7.4"
+    "version": "0.7.6"
   },
   "react-native-paper": {
     "name": "react-native-paper",

--- a/packages/shopping/package.json
+++ b/packages/shopping/package.json
@@ -14,14 +14,14 @@
     "check-deps": "rnx-align-deps"
   },
   "dependencies": {
-    "@bottom-tabs/react-navigation": "0.7.3",
+    "@bottom-tabs/react-navigation": "0.7.4",
     "@module-federation/enhanced": "0.7.1",
     "@react-native-async-storage/async-storage": "2.0.0",
     "@react-navigation/native": "7.0.13",
     "@react-navigation/native-stack": "7.1.14",
     "react": "18.3.1",
     "react-native": "0.76.3",
-    "react-native-bottom-tabs": "0.7.3",
+    "react-native-bottom-tabs": "0.7.4",
     "react-native-edge-to-edge": "1.1.3",
     "react-native-paper": "5.12.5",
     "react-native-safe-area-context": "4.12.0",

--- a/packages/shopping/package.json
+++ b/packages/shopping/package.json
@@ -14,14 +14,14 @@
     "check-deps": "rnx-align-deps"
   },
   "dependencies": {
-    "@bottom-tabs/react-navigation": "0.7.4",
+    "@bottom-tabs/react-navigation": "0.7.6",
     "@module-federation/enhanced": "0.7.1",
     "@react-native-async-storage/async-storage": "2.0.0",
     "@react-navigation/native": "7.0.13",
     "@react-navigation/native-stack": "7.1.14",
     "react": "18.3.1",
     "react-native": "0.76.3",
-    "react-native-bottom-tabs": "0.7.4",
+    "react-native-bottom-tabs": "0.7.6",
     "react-native-edge-to-edge": "1.1.3",
     "react-native-paper": "5.12.5",
     "react-native-safe-area-context": "4.12.0",

--- a/packages/shopping/src/components/NavBar.tsx
+++ b/packages/shopping/src/components/NavBar.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import {NativeStackHeaderProps} from '@react-navigation/native-stack';
-import {Appbar} from 'react-native-paper';
+import {Appbar, MD3Colors} from 'react-native-paper';
 
 const NavBar = ({navigation, back, route, options}: NativeStackHeaderProps) => {
   return (
-    <Appbar.Header elevated>
+    <Appbar.Header elevated style={{backgroundColor: MD3Colors.primary95}}>
       {back ? <Appbar.BackAction onPress={navigation.goBack} /> : null}
       <Appbar.Content title={options.title ?? route.name} />
     </Appbar.Header>

--- a/packages/shopping/src/navigation/TabsNavigator.tsx
+++ b/packages/shopping/src/navigation/TabsNavigator.tsx
@@ -20,7 +20,9 @@ const Tabs = createNativeBottomTabNavigator<TabsParamList>();
 
 const TabsNavigator = () => {
   return (
-    <Tabs.Navigator tabBarActiveTintColor={MD3Colors.primary50}>
+    <Tabs.Navigator
+      translucent={false}
+      tabBarActiveTintColor={MD3Colors.primary50}>
       <Tabs.Screen
         name="HomeNavigator"
         component={HomeNavigator}

--- a/packages/shopping/src/navigation/TabsNavigator.tsx
+++ b/packages/shopping/src/navigation/TabsNavigator.tsx
@@ -22,7 +22,8 @@ const TabsNavigator = () => {
   return (
     <Tabs.Navigator
       translucent={false}
-      tabBarActiveTintColor={MD3Colors.primary50}>
+      tabBarActiveTintColor={MD3Colors.primary50}
+      barTintColor={MD3Colors.primary95}>
       <Tabs.Screen
         name="HomeNavigator"
         component={HomeNavigator}

--- a/patches/react-native-paper.patch
+++ b/patches/react-native-paper.patch
@@ -1,15 +1,12 @@
-diff --git a/src/components/BottomNavigation/BottomNavigationBar.tsx b/src/components/BottomNavigation/BottomNavigationBar.tsx
-index 0bfe303bfb443396ede776726faa0f8ba32752cd..789c38829eae0030484787d4e5ab4b36b01c2765 100644
---- a/src/components/BottomNavigation/BottomNavigationBar.tsx
-+++ b/src/components/BottomNavigation/BottomNavigationBar.tsx
-@@ -360,7 +360,9 @@ const BottomNavigationBar = <Route extends BaseRoute>({
-   navigationState,
-   renderIcon,
-   renderLabel,
--  renderTouchable = (props: TouchableProps<Route>) => <Touchable {...props} />,
-+  renderTouchable = ({ key, ...props }: TouchableProps<Route>) => (
-+    <Touchable key={key} {...props} />
-+  ),
-   getLabelText = ({ route }: { route: Route }) => route.title,
-   getBadge = ({ route }: { route: Route }) => route.badge,
-   getColor = ({ route }: { route: Route }) => route.color,
+diff --git a/src/components/Card/CardCover.tsx b/src/components/Card/CardCover.tsx
+index 337de2a94402e3e82908e4b00cffcc9cef2bd97b..e0147381dc866a4a4106780c808d89bd7e118e2f 100644
+--- a/src/components/Card/CardCover.tsx
++++ b/src/components/Card/CardCover.tsx
+@@ -86,7 +86,6 @@ const styles = StyleSheet.create({
+     flex: 1,
+     height: undefined,
+     width: undefined,
+-    padding: 16,
+     justifyContent: 'flex-end',
+   },
+ });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
   packages/auth:
     dependencies:
       '@bottom-tabs/react-navigation':
-        specifier: 0.7.4
-        version: 0.7.4(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: 0.7.6
+        version: 0.7.6(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.6(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@module-federation/enhanced':
         specifier: 0.7.1
         version: 0.7.1(react@18.3.1)(typescript@5.6.3)(webpack@5.95.0)
@@ -49,8 +49,8 @@ importers:
         specifier: 0.76.3
         version: 0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1)
       react-native-bottom-tabs:
-        specifier: 0.7.4
-        version: 0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: 0.7.6
+        version: 0.7.6(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-edge-to-edge:
         specifier: 1.1.3
         version: 1.1.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -155,8 +155,8 @@ importers:
   packages/booking:
     dependencies:
       '@bottom-tabs/react-navigation':
-        specifier: 0.7.4
-        version: 0.7.4(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: 0.7.6
+        version: 0.7.6(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.6(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@module-federation/enhanced':
         specifier: 0.7.1
         version: 0.7.1(react@18.3.1)(typescript@5.6.3)(webpack@5.95.0)
@@ -176,8 +176,8 @@ importers:
         specifier: 0.76.3
         version: 0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1)
       react-native-bottom-tabs:
-        specifier: 0.7.4
-        version: 0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: 0.7.6
+        version: 0.7.6(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-calendars:
         specifier: 1.1291.1
         version: 1.1291.1(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -285,8 +285,8 @@ importers:
   packages/dashboard:
     dependencies:
       '@bottom-tabs/react-navigation':
-        specifier: 0.7.4
-        version: 0.7.4(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: 0.7.6
+        version: 0.7.6(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.6(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@module-federation/enhanced':
         specifier: 0.7.1
         version: 0.7.1(react@18.3.1)(typescript@5.6.3)(webpack@5.95.0)
@@ -306,8 +306,8 @@ importers:
         specifier: 0.76.3
         version: 0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1)
       react-native-bottom-tabs:
-        specifier: 0.7.4
-        version: 0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: 0.7.6
+        version: 0.7.6(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-calendars:
         specifier: 1.1291.1
         version: 1.1291.1(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -415,8 +415,8 @@ importers:
   packages/host:
     dependencies:
       '@bottom-tabs/react-navigation':
-        specifier: 0.7.4
-        version: 0.7.4(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: 0.7.6
+        version: 0.7.6(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.6(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@module-federation/enhanced':
         specifier: 0.7.1
         version: 0.7.1(react@18.3.1)(typescript@5.6.3)(webpack@5.95.0)
@@ -439,8 +439,8 @@ importers:
         specifier: 6.2.6
         version: 6.2.6(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-bottom-tabs:
-        specifier: 0.7.4
-        version: 0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: 0.7.6
+        version: 0.7.6(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-edge-to-edge:
         specifier: 1.1.3
         version: 1.1.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -550,8 +550,8 @@ importers:
   packages/shopping:
     dependencies:
       '@bottom-tabs/react-navigation':
-        specifier: 0.7.4
-        version: 0.7.4(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: 0.7.6
+        version: 0.7.6(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.6(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@module-federation/enhanced':
         specifier: 0.7.1
         version: 0.7.1(react@18.3.1)(typescript@5.6.3)(webpack@5.95.0)
@@ -571,8 +571,8 @@ importers:
         specifier: 0.76.3
         version: 0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1)
       react-native-bottom-tabs:
-        specifier: 0.7.4
-        version: 0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: 0.7.6
+        version: 0.7.6(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-edge-to-edge:
         specifier: 1.1.3
         version: 1.1.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -1371,8 +1371,8 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@bottom-tabs/react-navigation@0.7.4':
-    resolution: {integrity: sha512-wrXQPfJjBMsIPKfAqGZEePZ3JMHNl22Mbtdugq37NtU9ftILYkTUJLIug7AKHqljwKG9ZutMht1DDXIoBsmZDw==}
+  '@bottom-tabs/react-navigation@0.7.6':
+    resolution: {integrity: sha512-2RaG4lWKrJSZLzt27asmDiDkxX7jMF6q3o79zCF2eE7eELq7SWWPs5l5ywN8qMqlL1YXSU4hoj7Tz7TdGV2oxQ==}
     peerDependencies:
       '@react-navigation/native': '>=7'
       react: '*'
@@ -4687,8 +4687,8 @@ packages:
       react: '>=18.1.0'
       react-native: '>=0.70.0'
 
-  react-native-bottom-tabs@0.7.4:
-    resolution: {integrity: sha512-v00HToTp8h8TshQJxH8UAmcEY6/wzDkvmS/uZgd8kO0AQOMaCqPl4WaA97aaCauqPqwOv8ejLopX4QH2SzVI1Q==}
+  react-native-bottom-tabs@0.7.6:
+    resolution: {integrity: sha512-F9qdUnMGoNWHGzFux/u6GkMKPCYFWgoCXUd8DxmeKVlk/jhBM4ybhqnQrPdFm8pfF7f4FT10YSc22IjAhWAAMw==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -6533,13 +6533,13 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@bottom-tabs/react-navigation@0.7.4(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+  '@bottom-tabs/react-navigation@0.7.6(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.6(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-navigation/native': 7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       color: 4.2.3
       react: 18.3.1
       react-native: 0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1)
-      react-native-bottom-tabs: 0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-bottom-tabs: 0.7.6(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
 
   '@callstack/react-theme-provider@3.0.9(react@18.3.1)':
     dependencies:
@@ -10826,7 +10826,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-native-bottom-tabs@0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
+  react-native-bottom-tabs@0.7.6(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-native: 0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
   packages/auth:
     dependencies:
       '@bottom-tabs/react-navigation':
-        specifier: 0.7.3
-        version: 0.7.3(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: 0.7.4
+        version: 0.7.4(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@module-federation/enhanced':
         specifier: 0.7.1
         version: 0.7.1(react@18.3.1)(typescript@5.6.3)(webpack@5.95.0)
@@ -49,8 +49,8 @@ importers:
         specifier: 0.76.3
         version: 0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1)
       react-native-bottom-tabs:
-        specifier: 0.7.3
-        version: 0.7.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: 0.7.4
+        version: 0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-edge-to-edge:
         specifier: 1.1.3
         version: 1.1.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -155,8 +155,8 @@ importers:
   packages/booking:
     dependencies:
       '@bottom-tabs/react-navigation':
-        specifier: 0.7.3
-        version: 0.7.3(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: 0.7.4
+        version: 0.7.4(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@module-federation/enhanced':
         specifier: 0.7.1
         version: 0.7.1(react@18.3.1)(typescript@5.6.3)(webpack@5.95.0)
@@ -176,8 +176,8 @@ importers:
         specifier: 0.76.3
         version: 0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1)
       react-native-bottom-tabs:
-        specifier: 0.7.3
-        version: 0.7.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: 0.7.4
+        version: 0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-calendars:
         specifier: 1.1291.1
         version: 1.1291.1(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -285,8 +285,8 @@ importers:
   packages/dashboard:
     dependencies:
       '@bottom-tabs/react-navigation':
-        specifier: 0.7.3
-        version: 0.7.3(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: 0.7.4
+        version: 0.7.4(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@module-federation/enhanced':
         specifier: 0.7.1
         version: 0.7.1(react@18.3.1)(typescript@5.6.3)(webpack@5.95.0)
@@ -306,8 +306,8 @@ importers:
         specifier: 0.76.3
         version: 0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1)
       react-native-bottom-tabs:
-        specifier: 0.7.3
-        version: 0.7.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: 0.7.4
+        version: 0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-calendars:
         specifier: 1.1291.1
         version: 1.1291.1(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -415,8 +415,8 @@ importers:
   packages/host:
     dependencies:
       '@bottom-tabs/react-navigation':
-        specifier: 0.7.3
-        version: 0.7.3(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: 0.7.4
+        version: 0.7.4(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@module-federation/enhanced':
         specifier: 0.7.1
         version: 0.7.1(react@18.3.1)(typescript@5.6.3)(webpack@5.95.0)
@@ -439,8 +439,8 @@ importers:
         specifier: 6.2.6
         version: 6.2.6(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-bottom-tabs:
-        specifier: 0.7.3
-        version: 0.7.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: 0.7.4
+        version: 0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-edge-to-edge:
         specifier: 1.1.3
         version: 1.1.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -550,8 +550,8 @@ importers:
   packages/shopping:
     dependencies:
       '@bottom-tabs/react-navigation':
-        specifier: 0.7.3
-        version: 0.7.3(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: 0.7.4
+        version: 0.7.4(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@module-federation/enhanced':
         specifier: 0.7.1
         version: 0.7.1(react@18.3.1)(typescript@5.6.3)(webpack@5.95.0)
@@ -571,8 +571,8 @@ importers:
         specifier: 0.76.3
         version: 0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1)
       react-native-bottom-tabs:
-        specifier: 0.7.3
-        version: 0.7.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: 0.7.4
+        version: 0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-edge-to-edge:
         specifier: 1.1.3
         version: 1.1.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -1371,8 +1371,8 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@bottom-tabs/react-navigation@0.7.3':
-    resolution: {integrity: sha512-by9BeCfHx/EbxkWhnpYbnxg4dhurbOCKmFbEXuFywhKLY1iD0MrQ6BrEX3wH6+m5XH6TBcst7fxq0LQWIOLnpw==}
+  '@bottom-tabs/react-navigation@0.7.4':
+    resolution: {integrity: sha512-wrXQPfJjBMsIPKfAqGZEePZ3JMHNl22Mbtdugq37NtU9ftILYkTUJLIug7AKHqljwKG9ZutMht1DDXIoBsmZDw==}
     peerDependencies:
       '@react-navigation/native': '>=7'
       react: '*'
@@ -4687,8 +4687,8 @@ packages:
       react: '>=18.1.0'
       react-native: '>=0.70.0'
 
-  react-native-bottom-tabs@0.7.3:
-    resolution: {integrity: sha512-aaLQRkN8lBf2VRN21Kreb3jsGUl5zNunOOMEtNfXrAVJ1EFNqBInbJ8ujJnS3yIcx/upiLNSDll3HTYEweaE+Q==}
+  react-native-bottom-tabs@0.7.4:
+    resolution: {integrity: sha512-v00HToTp8h8TshQJxH8UAmcEY6/wzDkvmS/uZgd8kO0AQOMaCqPl4WaA97aaCauqPqwOv8ejLopX4QH2SzVI1Q==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -6533,13 +6533,13 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@bottom-tabs/react-navigation@0.7.3(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+  '@bottom-tabs/react-navigation@0.7.4(@react-navigation/native@7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-bottom-tabs@0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-navigation/native': 7.0.13(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       color: 4.2.3
       react: 18.3.1
       react-native: 0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1)
-      react-native-bottom-tabs: 0.7.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-bottom-tabs: 0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
 
   '@callstack/react-theme-provider@3.0.9(react@18.3.1)':
     dependencies:
@@ -10826,7 +10826,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-native-bottom-tabs@0.7.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
+  react-native-bottom-tabs@0.7.4(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-native: 0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ patchedDependencies:
     hash: gdpi5rwh3blcwxgyspzwxjdb6a
     path: patches/@react-native__community-cli-plugin.patch
   react-native-paper:
-    hash: y63saubgvw44zriplyaexrq2dy
+    hash: jbcjvd6hhp2gtyomtoldpygoay
     path: patches/react-native-paper.patch
 
 importers:
@@ -56,7 +56,7 @@ importers:
         version: 1.1.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-paper:
         specifier: 5.12.5
-        version: 5.12.5(patch_hash=y63saubgvw44zriplyaexrq2dy)(react-native-safe-area-context@4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-vector-icons@10.2.0)(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 5.12.5(patch_hash=jbcjvd6hhp2gtyomtoldpygoay)(react-native-safe-area-context@4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-vector-icons@10.2.0)(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-safe-area-context:
         specifier: 4.12.0
         version: 4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -186,7 +186,7 @@ importers:
         version: 1.1.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-paper:
         specifier: 5.12.5
-        version: 5.12.5(patch_hash=y63saubgvw44zriplyaexrq2dy)(react-native-safe-area-context@4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-vector-icons@10.2.0)(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 5.12.5(patch_hash=jbcjvd6hhp2gtyomtoldpygoay)(react-native-safe-area-context@4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-vector-icons@10.2.0)(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-safe-area-context:
         specifier: 4.12.0
         version: 4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -316,7 +316,7 @@ importers:
         version: 1.1.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-paper:
         specifier: 5.12.5
-        version: 5.12.5(patch_hash=y63saubgvw44zriplyaexrq2dy)(react-native-safe-area-context@4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-vector-icons@10.2.0)(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 5.12.5(patch_hash=jbcjvd6hhp2gtyomtoldpygoay)(react-native-safe-area-context@4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-vector-icons@10.2.0)(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-safe-area-context:
         specifier: 4.12.0
         version: 4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -446,7 +446,7 @@ importers:
         version: 1.1.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-paper:
         specifier: 5.12.5
-        version: 5.12.5(patch_hash=y63saubgvw44zriplyaexrq2dy)(react-native-safe-area-context@4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-vector-icons@10.2.0)(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 5.12.5(patch_hash=jbcjvd6hhp2gtyomtoldpygoay)(react-native-safe-area-context@4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-vector-icons@10.2.0)(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-safe-area-context:
         specifier: 4.12.0
         version: 4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -578,7 +578,7 @@ importers:
         version: 1.1.3(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-paper:
         specifier: 5.12.5
-        version: 5.12.5(patch_hash=y63saubgvw44zriplyaexrq2dy)(react-native-safe-area-context@4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-vector-icons@10.2.0)(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 5.12.5(patch_hash=jbcjvd6hhp2gtyomtoldpygoay)(react-native-safe-area-context@4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-vector-icons@10.2.0)(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-safe-area-context:
         specifier: 4.12.0
         version: 4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -10859,7 +10859,7 @@ snapshots:
       react: 18.3.1
       react-native: 0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1)
 
-  react-native-paper@5.12.5(patch_hash=y63saubgvw44zriplyaexrq2dy)(react-native-safe-area-context@4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-vector-icons@10.2.0)(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
+  react-native-paper@5.12.5(patch_hash=jbcjvd6hhp2gtyomtoldpygoay)(react-native-safe-area-context@4.12.0(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-vector-icons@10.2.0)(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.2.27)(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
     dependencies:
       '@callstack/react-theme-provider': 3.0.9(react@18.3.1)
       color: 3.2.1


### PR DESCRIPTION
### Summary

- [x] - fixed 'See All' button on iOS text being ellipsized instead of being showing in full
- [x] - fixed differences between padding for `Card.Cover` from RNP
- [x] - removed old patch for RNP
- [x] - use BottomTabScreen from RNBT instead of RNP
- [x] - make BottomTabBar opaque on iOS 
- [x] - align top and bottom bars color-wise on both platforms

### Screenshots

| ios | android |
| - | - |
| ![image](https://github.com/user-attachments/assets/611b3aeb-80cb-4129-810b-21f685d7aecf) | ![image](https://github.com/user-attachments/assets/0d075d34-dd3f-4740-af00-5bb5cf07f517) |



### Test plan

- [x] - Apps on iOS and Android match visually
