### PR TITLE
fix: resolve junctions on Windows

### DIFF
--- a/packages/sdk/android/resolveNodePackage.gradle
+++ b/packages/sdk/android/resolveNodePackage.gradle
@@ -1,17 +1,21 @@
 // source: https://github.com/facebook/react-native/pull/39520
 // TODO remove in the future when this lands in RN
+// modified to better support resolving symlinks(junctions) on Windows
+
+import java.nio.file.*
 
 ext.resolveNodePackage = { String packageName, File startDir ->
-    def candidate = new File(startDir, "node_modules/$packageName")
+    def startPath = startDir.toPath()
+    def candidate = startPath.resolve("node_modules").resolve(packageName)
 
-    if (candidate.exists()) {
-        return candidate.canonicalFile
+    if (Files.exists(candidate)) {
+        return candidate.toRealPath().toFile()
     }
 
-    def parentDir = startDir.parentFile
-    if (parentDir == null || startDir.canonicalPath == parentDir.canonicalPath) {
+    def parentDir = startPath.parent
+    if (parentDir == null || startPath.toRealPath() == parentDir.toRealPath()) {
         throw new GradleException("Failed to find the package '$packageName'. Ensure you have installed node_modules.")
     }
 
-    return resolveNodePackage(packageName, parentDir)
+    return resolveNodePackage(packageName, parentDir.toFile())
 }


### PR DESCRIPTION
### Summary

Closes #109

This is partial solution to the problem in #109 - the custom gradle script is now able to resolve symlinks (junctions) on Windows correctly when resolving react native related gradle scripts.

Despite this fix, building on Windows is still blocked by https://github.com/gradle/gradle/issues/28974 and it's not possible to revert to Gradle 8.5 (which doesn't have this problem) due to RN constraints

### Test plan

- [ ] - builds for android on Windows succesfully 
