### PR TITLE
chore: enable Module Federation's dts

### DIFF
--- a/packages/auth/rspack.config.mjs
+++ b/packages/auth/rspack.config.mjs
@@ -181,7 +181,6 @@ export default env => {
          */
         name: 'auth',
         filename: 'auth.container.js.bundle',
-        dts: false,
         /**
          * This is a list of modules that will be shared between remote containers.
          */

--- a/packages/auth/webpack.config.mjs
+++ b/packages/auth/webpack.config.mjs
@@ -210,7 +210,6 @@ export default env => {
          */
         name: 'auth',
         filename: 'auth.container.js.bundle',
-        dts: false,
         /**
          * This is a list of modules that will be shared between remote containers.
          */

--- a/packages/booking/rspack.config.mjs
+++ b/packages/booking/rspack.config.mjs
@@ -181,7 +181,6 @@ export default env => {
          */
         name: 'booking',
         filename: 'booking.container.js.bundle',
-        dts: false,
         /**
          * This is a list of modules that will be shared between remote containers.
          */

--- a/packages/booking/webpack.config.mjs
+++ b/packages/booking/webpack.config.mjs
@@ -210,7 +210,6 @@ export default env => {
          */
         name: 'booking',
         filename: 'booking.container.js.bundle',
-        dts: false,
         /**
          * This is a list of modules that will be shared between remote containers.
          */

--- a/packages/dashboard/rspack.config.mjs
+++ b/packages/dashboard/rspack.config.mjs
@@ -187,7 +187,6 @@ export default env => {
          */
         name: 'dashboard',
         filename: 'dashboard.container.js.bundle',
-        dts: false,
         /**
          * This is a list of modules that will be shared between remote containers.
          */

--- a/packages/dashboard/webpack.config.mjs
+++ b/packages/dashboard/webpack.config.mjs
@@ -216,7 +216,6 @@ export default env => {
          */
         name: 'dashboard',
         filename: 'dashboard.container.js.bundle',
-        dts: false,
         /**
          * This is a list of modules that will be shared between remote containers.
          */

--- a/packages/host/rspack.config.mjs
+++ b/packages/host/rspack.config.mjs
@@ -178,7 +178,6 @@ export default env => {
          * The name of the module is used to identify the module in URLs resolver and imports.
          */
         name: 'host',
-        dts: false,
         remotes: {
           booking: `booking@http://localhost:9000/${platform}/mf-manifest.json`,
           shopping: `shopping@http://localhost:9001/${platform}/mf-manifest.json`,

--- a/packages/host/webpack.config.mjs
+++ b/packages/host/webpack.config.mjs
@@ -208,7 +208,6 @@ export default env => {
          * The name of the module is used to identify the module in URLs resolver and imports.
          */
         name: 'host',
-        dts: false,
         remotes: {
           booking: `booking@http://localhost:9000/${platform}/mf-manifest.json`,
           shopping: `shopping@http://localhost:9001/${platform}/mf-manifest.json`,

--- a/packages/shopping/rspack.config.mjs
+++ b/packages/shopping/rspack.config.mjs
@@ -181,7 +181,6 @@ export default env => {
          */
         name: 'shopping',
         filename: 'shopping.container.js.bundle',
-        dts: false,
         /**
          * This is a list of modules that will be shared between remote containers.
          */

--- a/packages/shopping/webpack.config.mjs
+++ b/packages/shopping/webpack.config.mjs
@@ -210,7 +210,6 @@ export default env => {
          */
         name: 'shopping',
         filename: 'shopping.container.js.bundle',
-        dts: false,
         /**
          * This is a list of modules that will be shared between remote containers.
          */


### PR DESCRIPTION
This should work, but currently 'dts' generation fails for all remotes.

Exception thrown inside `dts-plugin`.

We should use this a preproduction, until fixed.