### PR TITLE
Fix trading sheet tab bar spacing

### DIFF
--- a/packages/trading/src/components/TradeBottomSheet.tsx
+++ b/packages/trading/src/components/TradeBottomSheet.tsx
@@ -39,6 +39,17 @@ const TradeBottomSheet = React.forwardRef<BottomSheetRef, Props>(
   ({ asset, bottomInset, onConfirm }, ref) => {
     const sheetRef = React.useRef<BottomSheet>(null);
     const amountRef = React.useRef('');
+    const [keyboardVisible, setKeyboardVisible] = React.useState(() => Keyboard.isVisible());
+
+    React.useEffect(() => {
+      const willShowSub = Keyboard.addListener('keyboardWillShow', () => setKeyboardVisible(true));
+      const willHideSub = Keyboard.addListener('keyboardWillHide', () => setKeyboardVisible(false));
+
+      return () => {
+        willShowSub.remove();
+        willHideSub.remove();
+      };
+    }, []);
 
     const closeSheet = React.useCallback(() => {
       Keyboard.dismiss();
@@ -73,7 +84,7 @@ const TradeBottomSheet = React.forwardRef<BottomSheetRef, Props>(
         handleIndicatorStyle={styles.indicator}
         onClose={Keyboard.dismiss}>
         <BottomSheetView
-          style={[styles.content, {paddingBottom: bottomInset + 16}]}>
+          style={[styles.content, {paddingBottom: keyboardVisible ? 32 : Math.max(32, bottomInset + 16) }]}>
           <Text style={styles.title}>Trade {asset.name}</Text>
           <Text style={styles.subtitle}>{asset.symbol}/USD</Text>
 
@@ -125,7 +136,6 @@ const styles = StyleSheet.create({
   content: {
     paddingHorizontal: 24,
     paddingTop: 8,
-    paddingBottom: 32,
     gap: 16,
   },
   title: {

--- a/packages/trading/src/components/TradeBottomSheet.tsx
+++ b/packages/trading/src/components/TradeBottomSheet.tsx
@@ -21,6 +21,7 @@ export interface BottomSheetRef {
 
 interface Props {
   asset: Asset;
+  bottomInset: number;
   onConfirm: () => void;
 }
 
@@ -35,7 +36,7 @@ const renderBackdrop = (props: BottomSheetBackdropProps) => (
 );
 
 const TradeBottomSheet = React.forwardRef<BottomSheetRef, Props>(
-  ({asset, onConfirm}, ref) => {
+  ({ asset, bottomInset, onConfirm }, ref) => {
     const sheetRef = React.useRef<BottomSheet>(null);
     const amountRef = React.useRef('');
 
@@ -71,7 +72,8 @@ const TradeBottomSheet = React.forwardRef<BottomSheetRef, Props>(
         backgroundStyle={styles.background}
         handleIndicatorStyle={styles.indicator}
         onClose={Keyboard.dismiss}>
-        <BottomSheetView style={styles.content}>
+        <BottomSheetView
+          style={[styles.content, {paddingBottom: bottomInset + 16}]}>
           <Text style={styles.title}>Trade {asset.name}</Text>
           <Text style={styles.subtitle}>{asset.symbol}/USD</Text>
 

--- a/packages/trading/src/screens/AssetDetailsScreen.tsx
+++ b/packages/trading/src/screens/AssetDetailsScreen.tsx
@@ -78,7 +78,7 @@ const AssetDetailsScreen = ({route, navigation}: Props) => {
     Platform.OS === 'ios'
       // sometimes the first render would get 0 for tab bar height
       ? Math.max(tabBarHeight, IOS_TAB_BAR_FALLBACK_HEIGHT + insets.bottom)
-      : tabBarHeight;
+      : 0;
   const footerPaddingBottom =
     Platform.OS === 'ios' ? effectiveTabBarHeight + 8 : 16;
   const price = useAssetPrice(asset.symbol);

--- a/packages/trading/src/screens/AssetDetailsScreen.tsx
+++ b/packages/trading/src/screens/AssetDetailsScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -7,6 +8,7 @@ import {
   View,
 } from 'react-native';
 import {useBottomTabBarHeight} from 'react-native-bottom-tabs';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {matchFont} from '@shopify/react-native-skia';
 import {CartesianChart, Line} from 'victory-native';
 import {useDerivedValue, useSharedValue, withTiming} from 'react-native-reanimated';
@@ -39,6 +41,7 @@ if (__DEV__ && !(console as PatchableConsole).__skiaAddPathWarnPatched) {
 type Props = NativeStackScreenProps<TradingStackParamList, 'AssetDetails'>;
 
 const MAX_TICKS = 60;
+const IOS_TAB_BAR_FALLBACK_HEIGHT = 49;
 
 const NEWS_ITEMS = [
   {
@@ -70,6 +73,14 @@ const NEWS_ITEMS = [
 const AssetDetailsScreen = ({route, navigation}: Props) => {
   const {asset} = route.params;
   const tabBarHeight = useBottomTabBarHeight();
+  const insets = useSafeAreaInsets();
+  const effectiveTabBarHeight =
+    Platform.OS === 'ios'
+      // sometimes the first render would get 0 for tab bar height
+      ? Math.max(tabBarHeight, IOS_TAB_BAR_FALLBACK_HEIGHT + insets.bottom)
+      : tabBarHeight;
+  const footerPaddingBottom =
+    Platform.OS === 'ios' ? effectiveTabBarHeight + 8 : 16;
   const price = useAssetPrice(asset.symbol);
   const historicalPrices = useHistoricalPrices(asset.krakenPair);
   const prevPriceRef = React.useRef(0);
@@ -209,7 +220,7 @@ const AssetDetailsScreen = ({route, navigation}: Props) => {
       </ScrollView>
 
       {/* Trade button */}
-      <View style={[styles.footer, {paddingBottom: tabBarHeight + 8}]}>
+      <View style={[styles.footer, {paddingBottom: footerPaddingBottom}]}>
         <Pressable
           style={({pressed}) => [
             styles.tradeButton,
@@ -223,6 +234,7 @@ const AssetDetailsScreen = ({route, navigation}: Props) => {
       <TradeBottomSheet
         ref={tradeSheetRef}
         asset={asset}
+        bottomInset={effectiveTabBarHeight}
         onConfirm={() => {
           navigation.navigate('TradeSuccess', {symbol: asset.symbol});
         }}


### PR DESCRIPTION
### Summary

Fixes spacing for the trading flow around the native bottom tab bar.

The trade bottom sheet now receives the tab bar inset from the asset details screen and uses it as bottom content padding, so the sheet content stays clear of the tabs while the sheet can still present from the bottom. The trade button footer also keeps compact Android padding while preserving iOS tab bar clearance.

The iOS tab bar height can briefly report as zero on initial render, so the details screen uses a standard tab bar height plus safe-area inset as a fallback.

### Test plan

- Open an asset details screen on iOS and tap Trade. Confirm the bottom sheet actions are not covered by the tab bar.
- Focus the amount input on iOS. Confirm the sheet works with the keyboard open and with keyboard closed
- Open an asset details screen on Android. Confirm the sheet works with the keyboard open and with keyboard closed

<img width="443" height="897" alt="image" src="https://github.com/user-attachments/assets/3c32a77b-7b43-48db-8156-f09c38c7d102" />

<img width="443" height="897" alt="image" src="https://github.com/user-attachments/assets/04ac0191-ff90-44f5-9d57-f4437a6cb018" />


